### PR TITLE
fix: translates missing/wrong on some places

### DIFF
--- a/public/locales/en/profilePets.json
+++ b/public/locales/en/profilePets.json
@@ -5,7 +5,7 @@
   "goToProfile": "Go to the shelter profile",
   "adoptWhatsapp": "Contact Shelter",
   "requiredToAdoption": "Adoption requirements",
-  "medicalInformation": "Medical information",
+  "medicalRecords": "Medical records",
   "history": "History",
   "lost": "It's lost",
   "vaccinated": "Vaccinated",

--- a/public/locales/es/profilePets.json
+++ b/public/locales/es/profilePets.json
@@ -4,7 +4,7 @@
   "title": "Mi nombre es {{ name }}",
   "goToProfile": "Ir al perfil del refugio",
   "requiredToAdoption": "Requisitos pada adoptar",
-  "medicalRecords": "Medical records",
+  "medicalRecords": "Historia clínica",
   "history": "Historia",
   "adoptWhatsapp": "Contactar Refugio",
   "lost": "Esta Perdida",

--- a/src/containers/Dashboard/DashboardAdopter/DashboardAdopter.jsx
+++ b/src/containers/Dashboard/DashboardAdopter/DashboardAdopter.jsx
@@ -61,7 +61,7 @@ const DashboardAdopter = () => {
         <DashboardCard
           handleClick={handleSearch}
           icon={<MdSearch size={25} />}
-          titleCard={t('common:searchPets')}
+          titleCard={t('navbar:searchPets')}
         />
         <DashboardCard
           titleCard={t('searchShelters')}


### PR DESCRIPTION
I was looking for some styles improvements when I realized that there are some missing/wrong translations.

### SearchPets

**Before**
<img width="366" alt="Captura de Pantalla 2020-10-20 a la(s) 08 27 38" src="https://user-images.githubusercontent.com/12776211/96580629-f214f000-12ae-11eb-87f4-2cfbec205ed5.png">

**After**
<img width="371" alt="Captura de Pantalla 2020-10-20 a la(s) 08 27 00" src="https://user-images.githubusercontent.com/12776211/96580626-f0e3c300-12ae-11eb-9416-eb03445bf500.png">

### PetProfile

**Before**
<img width="967" alt="Captura de Pantalla 2020-10-20 a la(s) 08 40 14" src="https://user-images.githubusercontent.com/12776211/96581271-f55cab80-12af-11eb-813b-aa9c456b38bb.png">

**After**
<img width="997" alt="Captura de Pantalla 2020-10-20 a la(s) 08 40 30" src="https://user-images.githubusercontent.com/12776211/96581281-f8579c00-12af-11eb-81df-ff472b107239.png">

