### PR TITLE
Fix: errors during test run

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,9 @@
 export default {
-  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', '!**/*.d.ts', '!**/node_modules/**'],
+  collectCoverageFrom: [
+    '**/*.{js,jsx,ts,tsx}',
+    '!**/*.d.ts',
+    '!**/node_modules/**',
+  ],
   moduleNameMapper: {
     // Handle CSS imports (with CSS modules)
     // https://jestjs.io/docs/webpack#mocking-css-modules
@@ -8,7 +12,8 @@ export default {
     '^.+\\.(css|sass|scss)$': '<rootDir>/src/tests/__mocks__/fileMock.js',
 
     // Handle image imports
-    '\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$': '<rootDir>/src/assets/icons',
+    '\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$':
+      '<rootDir>/src/assets/icons',
 
     // Handle module aliases
     '^@/components/(.*)$': '<rootDir>/src/components/$1',
@@ -19,8 +24,11 @@ export default {
   transform: {
     // Use babel-jest to transpile tests with the next/babel preset
     // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
-    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
+    '^.+\\.(js|jsx|ts|tsx)$': ['ts-jest'],
   },
-  transformIgnorePatterns: ['/node_modules/', '^.+\\.module\\.(css|sass|scss)$'],
+  transformIgnorePatterns: [
+    '/node_modules/',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ],
   testEnvironment: 'jest-environment-jsdom',
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["cypress", "jest", "@testing-library/jest-dom"],
 
@@ -21,6 +22,13 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "tests", "jest.config.js", "cypress.config.ts", "vite.config.ts"],
+  "include": [
+    "src",
+    "tests",
+    "jest.config.ts",
+    "jest.setup.ts",
+    "cypress.config.ts",
+    "vite.config.ts"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Hi,

This pull request fixes issue #179 

Following is the brief of changes:-
- **`jest.config.ts`** ==> Replaced `babel-jest` with `ts-jest` as the former one needed "next/babel" as preset (which means one more dependency).
- **`tsconfig.json`** ==> Added reference to jest setup file which was causing `@testing-library/jest-dom` method doesn't exist issue. Also, included `esModuleInterop` option to get rid of `ts-jest` warning messages during test run. And finally added correct extension of jest config file.